### PR TITLE
ignore hiden files and non python files in cob project root

### DIFF
--- a/cob/subsystems/manager.py
+++ b/cob/subsystems/manager.py
@@ -22,6 +22,8 @@ class SubsystemsManager(object):
         while roots:
             root = roots.pop()
             for name in os.listdir(root):
+                if os.path.isfile(name) and (name.startswith('.') or not name.endswith('.py')):
+                    continue
                 _logger.trace('Examining {}...', name)
                 path = os.path.join(root, name)
                 config = self._try_get_config(path)


### PR DESCRIPTION
updated subsystems/manager.py to ignore files like ">DS_store" or files not ending with ".py". checked by running migrate init in my area which passes flawlessly now.
