### PR TITLE
fix testserver auto reload on code change

### DIFF
--- a/cob/cli/main.py
+++ b/cob/cli/main.py
@@ -4,8 +4,8 @@ import sys
 import logbook
 import click
 
-from ..bootstrapping import ensure_project_bootstrapped
 
+from cob.bootstrapping import ensure_project_bootstrapped
 
 @click.group()
 @click.option("-v", "--verbose", count=True)


### PR DESCRIPTION
Hi,

i think this small fix will enable the auto reloading of testserver whenever the app code was changed. nevertheless ,if the code has a syntax error or something like it ,the testserver exists with an error/exception. is that the desired behavior ?
