### PR TITLE
add results backend to Celery app to enable results keeping

### DIFF
--- a/cob/celery_utils.py
+++ b/cob/celery_utils.py
@@ -14,7 +14,7 @@ class CobLoader(BaseLoader):
         build_app()
 
 
-celery_app = Celery('cob-celery', loader=CobLoader)
+celery_app = Celery('cob-celery', backend='rpc://', loader=CobLoader)
 
 
 def task(*, every=None, schedule=None, schedule_name=None, **kwargs):


### PR DESCRIPTION
Hi Rotem,

i would like to have the option of keeping results of celery tasks for later evaluating.
for this i added the backend to Celery app instance , let me know if rpc is a good option or we can use other options (see options here:  http://celery.readthedocs.io/en/latest/userguide/configuration.html#result-backend)

Thanks
Sivan