### PR TITLE
Avoid pip installation for project with no dependencies

### DIFF
--- a/cob/bootstrapping.py
+++ b/cob/bootstrapping.py
@@ -78,7 +78,8 @@ def _ensure_virtualenv():
         _virtualenv_pip_install(args)
 
     deps = sorted(get_project().get_deps())
-    _virtualenv_pip_install(['-U', *deps])
+    if deps:
+        _virtualenv_pip_install(['-U', *deps])
     with open(_INSTALLED_DEPS, 'w') as f:
         yaml.dump(deps, f)
 


### PR DESCRIPTION
According to the output for issue #73 , I found the when a project does not have dependencies, we still trying to pip install them.
```
✔ Creating virtualenv                                                                                                                                                                                              
✔ Installing /app/.cob-sdist.tar.gz in virtualenv                                                                                                                                                                  
✖ Installing  in virtualenv
Error: Execution failed with 1
Command: .cob/env/bin/python -m pip install -U
Logs can be found: /tmp/tmpb7xwc9ne
Stderr:
ERROR: You must give at least one requirement to install (see "pip help install")

The command '/bin/sh -c cob -vvv bootstrap' returned a non-zero code: 1
```
Starting from latest pip version, the bug for not returning errors for illegal pip commands was fixed therefore our travis jobs suddenly started failing.