### PR TITLE
Add automatic documentation for commands

### DIFF
--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -1,0 +1,5 @@
+Cob Commands
+============
+.. click::  cob.cli.main:main
+   :prog: cob
+   :show-nested:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,7 +33,7 @@
 import pkg_resources
 
 extensions = [
-    'sphinx.ext.autodoc', 'alabaster', 'releases',
+    'sphinx.ext.autodoc', 'alabaster', 'releases', 'sphinx_click.ext',
 ]
 
 releases_issue_uri = "https://github.com/getweber/cob/issues/%s"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,7 +24,7 @@ Cob is greatly inspired by *Ember CLI*, which also aimed at solving a similar pr
 Contents:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    getting_started
    basic_grains
@@ -41,6 +41,7 @@ Contents:
    developing
    environment
    api
+   commands
    changelog
 
 

--- a/doc/pip_requirements.txt
+++ b/doc/pip_requirements.txt
@@ -1,3 +1,4 @@
 alabaster
 setuptools>=35.0.0
 releases
+sphinx-click


### PR DESCRIPTION
`sphinx-click` is sphinx extension which creates automatic documentation for your click program.
I think it can be nice to add automatic documentation for cob.